### PR TITLE
Fix the block comments parsing

### DIFF
--- a/diddiparser/parser.py
+++ b/diddiparser/parser.py
@@ -91,11 +91,11 @@ class DiddiScriptFile:
             elif stop and "*/" in line:
                 # block comment ends
                 stop = False
-                continue
+                line = line[line.find("*/") + 2:].lstrip() # try to extract something after the comment block
             if "/*" in line:
                 # start block comment, stop reading
                 stop = True
-                continue
+                line = line[line.find("/*") - 1:].lstrip() # try to extract something command the comment block
             # replace the single-line comments
             cmd = line.split("!#")[0].rstrip()
             # enter the command

--- a/diddiparser/parser.py
+++ b/diddiparser/parser.py
@@ -95,7 +95,10 @@ class DiddiScriptFile:
             if "/*" in line:
                 # start block comment, stop reading
                 stop = True
-                line = line[line.find("/*") - 1:].lstrip() # try to extract something command the comment block
+                if "*/" in line:
+                    # it just covers one line, but it will be parsed as commonly
+                    stop = False
+                line = line[:line.find("/*")].lstrip() # try to extract something before the comment block
             # replace the single-line comments
             cmd = line.split("!#")[0].rstrip()
             # enter the command


### PR DESCRIPTION
With this change, the user could write code at the same line than the commentary block (just before it begins or at the same line it ends).

I'll explain it with a simple example. I want the users to write code like this:

```
openfile("C:/Users/Administrador/Documents/hello.txt"); /* A comment starts here.
It must end here */ pyrun('print("Hello world")');
```

Before this fix, DiddiParser dropped both lines (and ignored the `openfile()` and the `pyrun`). Now, I want to fix that.