### PR TITLE
Add a Colorama `install_requires`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+colorama
+setuptools
+pip >= 20

--- a/setup.py
+++ b/setup.py
@@ -39,5 +39,6 @@ setuptools.setup(
         "console_scripts": [
             "diddiparser=diddiparser.main:main"
         ]
-    }  
+    },
+    install_requires = ["colorama"] # require the colorama package
 )


### PR DESCRIPTION
It is used on `diddiparser.main`, on `main()`. I must include it as a dependency.