### PR TITLE
Add a `__license__` variable

### DIFF
--- a/diddiparser/__init__.py
+++ b/diddiparser/__init__.py
@@ -8,3 +8,4 @@ By Diego Ramirez (2015-2021).
 
 __version__ = "1.1.1"
 __author__ = "Diego Ramirez (dr01191115@gmail.com) @DiddiLeija on GitHub"
+__license__ = "MIT"


### PR DESCRIPTION
It is not so necessary, but it can be helpful.

It is intended to be used like this:

```python
>>>from diddiparser import __license__
>>>__license__
"MIT"
```